### PR TITLE
fix typo: `JuliaMonoMedium` -> `JuliaMono-Medium`

### DIFF
--- a/julia_font.tex
+++ b/julia_font.tex
@@ -7,5 +7,5 @@
     Extension = .ttf]
 \newfontface\JuliaMonoRegular{JuliaMono-Regular}
 \newfontface\JuliaMonoBold{JuliaMono-Bold}
-\setmonofont{JuliaMonoMedium}[Contextuals=Alternate]
+\setmonofont{JuliaMono-Medium}[Contextuals=Alternate]
 


### PR DESCRIPTION
Overleaf complains about this:

![image](https://user-images.githubusercontent.com/8684355/113503984-e02abf00-9567-11eb-97c4-e9a3aea3aa4c.png)

this PR fixes it. I have little knowledge about latex font setting, so I don't know if it's the right fix.