### PR TITLE
don't set global defaults in julia_listings, instead define a style for julia code

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # julia-mono-listings
 
-A custom Julia language style for the LaTeX `listings` package, and Unicode support for the [JuliaMono](https://juliamono.netlify.app/) font in a `lstlisting` environment. 
+A custom Julia language style for the LaTeX `listings` package, and Unicode support for the [JuliaMono](https://juliamono.netlify.app/) font in a `lstlisting` environment.
 - JuliaMono: https://github.com/cormullion/juliamono
 - Julia Unicode: https://docs.julialang.org/en/v1/manual/unicode-input
 - Julia pygments: https://github.com/sisl/pygments-julia
@@ -26,7 +26,7 @@ Typesetting the [*Thompson sampling algorithm*](https://github.com/mossr/Beautif
 }
 
 \begin{document}
-\begin{lstlisting}[language=JuliaLocal]
+\begin{lstlisting}[language=JuliaLocal, style=julia]
 using Distributions
 
 function thompson_sampling(𝛂, 𝛃, apply; T=100)

--- a/julia_listings.tex
+++ b/julia_listings.tex
@@ -22,7 +22,7 @@
     alsoletter=!?
 }
 
-\lstset{
+\lstdefinestyle{julia}{
     language         = Julia,
     backgroundcolor  = \color[HTML]{F2F2F2},
     basicstyle       = \JuliaMonoRegular\small\color[HTML]{19177C},


### PR DESCRIPTION
Directly calling `lstset` in `julia_listings.tex` sets default values for the `lstlisting` environment.
A user might unknowingly override them using `lstset` at a later place.
Using `lstset` the settings get applied to other programming languages too, which might be undesirable.

Therefore I changed this to create a new style via `lstdefinestyle{julia}`.
Passing the parameter `style=julia` to `\begin{lstlisting}` like `\begin{lstlisting}[style=julia]` applies the settings.